### PR TITLE
1106 2d6

### DIFF
--- a/tags/terminal/unix_utilities.py
+++ b/tags/terminal/unix_utilities.py
@@ -1,4 +1,4 @@
-from talon import Context, Module
+from talon import Context, Module, actions
 
 from ...core.user_settings import get_list_from_csv
 
@@ -88,7 +88,7 @@ ctx.lists["self.unix_utility"] = unix_utilities
 
 # 2. arguments
 
-default_unix_arguments = {"--help": "help"}
+default_unix_arguments = {"help": "help"}
 
 unix_arguments = get_list_from_csv(
     "unix_arguments.csv",
@@ -103,4 +103,10 @@ ctx.lists["self.unix_argument"] = unix_arguments
 @mod.capture(rule="{user.unix_argument}+")
 def unix_arguments(m) -> str:
     """A non-empty sequence of unix command arguments, preceded by a space."""
-    return " " + " ".join(m.unix_argument_list)
+    return " --".join([""] + m.unix_argument_list)
+
+
+@mod.capture(rule="( {user.unix_argument} | <user.text> )")
+def unix_free_form_argument(m) -> str:
+    """An argument name in kebab-case, with defined arguments being preferred."""
+    return actions.user.formatted_text(m, 'DASH_SEPARATED')

--- a/tags/terminal/unix_utilities.talon
+++ b/tags/terminal/unix_utilities.talon
@@ -13,3 +13,4 @@ param (single|sing) [<user.unix_free_form_argument>]:
     insert(" -{unix_free_form_argument or ''}")
 flag [<user.letter>]: " -{letter or ''}"
 # flag shift/ship/uppercase <letter> produces the uppercase variant
+dubdash: " -- "

--- a/tags/terminal/unix_utilities.talon
+++ b/tags/terminal/unix_utilities.talon
@@ -7,9 +7,9 @@ core {user.unix_utility} [<user.unix_arguments>] [over]:
     "{unix_utility}{args}"
 
 # standalone arguments (predefined arguments preferred)
-param [<user.unix_free_form_argument>]:
+param [<user.unix_free_form_argument>] [over]:
     insert(" --{unix_free_form_argument or ''}")
-param (single|sing) [<user.unix_free_form_argument>]:
+param (single|sing) [<user.unix_free_form_argument>] [over]:
     insert(" -{unix_free_form_argument or ''}")
 flag [<user.letter>]: " -{letter or ''}"
 # flag shift/ship/uppercase <letter> produces the uppercase variant

--- a/tags/terminal/unix_utilities.talon
+++ b/tags/terminal/unix_utilities.talon
@@ -1,14 +1,15 @@
 tag: user.unix_utilities
 -
 
-# curated list/ bag of commands approach:
-core {user.unix_utility} [<user.unix_arguments>]:
+# curated list of commands with defined arguments:
+core {user.unix_utility} [<user.unix_arguments>] [over]:
     args = unix_arguments or ""
     "{unix_utility}{args}"
 
-option <user.unix_arguments>: "{unix_arguments}"
-
-# generic formatting (from diskordanz/2d6)
-param [<user.text>]: user.insert_formatted(" --{text or ''}", "DASH_SEPARATED")
+# standalone arguments (predefined arguments preferred)
+param [<user.unix_free_form_argument>]:
+    insert(" --{unix_free_form_argument or ''}")
+param (single|sing) [<user.unix_free_form_argument>]:
+    insert(" -{unix_free_form_argument or ''}")
 flag [<user.letter>]: " -{letter or ''}"
 # flag shift/ship/uppercase <letter> produces the uppercase variant


### PR DESCRIPTION
I added the following:
* command termination with `over` and single-quote standalone arguments.  After toying with this, I am not sure whether this is strictly necessary. Maybe I am not good enough in fluid dictation to benefit from it.
* consolidation of `option` and `param` commands. it defaults to using kebab-case, prefers defined arguments from the CSV file. This allows adding commands with specific formating to the list, like `autosquash` instead of `auto-squash` or `formatted_with_snake_case` instead of `formatted-with-snake-case`.
* Drop the `--` from the CSV file
* Add command for adding POSIX [argument terminator](https://unix.stackexchange.com/questions/11376/what-does-double-dash-mean/590210#590210) `--`. 